### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "html"
   ],
   "dependencies": {
-    "google-cdn": "^0.5.1",
+    "google-cdn": "^0.6.0",
     "gulp-util": "^3.0.0",
     "through2": "^0.5.1"
   },


### PR DESCRIPTION
Issue in google-cdn (btford/grunt-google-cdn#54) fixed by updating dependency to v0.6.0.
